### PR TITLE
Change dependency package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Description
-A Laravel (4 / 5) Package for using the Imgur api. Internally we use [adyg/php-imgur-api-client](https://github.com/Adyg/php-imgur-api-client).
+A Laravel (4 / 5) Package for using the Imgur api. Internally we use [j0k3r/php-imgur-api-client](https://github.com/j0k3r/php-imgur-api-client).
 The package provides a service provider, some configuration and a facade, such that you should be able to get started with writing your app immediately.
 
-For more detailed documentation on how to use `adyg/php-imgur-api-client` you should look at their [documentation](https://github.com/Adyg/php-imgur-api-client/tree/master/doc).
+For more detailed documentation on how to use `j0k3r/php-imgur-api-client` you should look at their [documentation](https://github.com/j0k3r/php-imgur-api-client).
 
 ### Quick example
 ```php

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "~5.0 || ~4.0",
-        "adyg/php-imgur-api-client": "~1.0.0"
+        "j0k3r/php-imgur-api-client": "^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Change `adyg/php-imgur-api-client` to `j0k3r/php-imgur-api-client` and update version.
Because [adyg/php-imgur-api-client](https://packagist.org/packages/adyg/php-imgur-api-client) is marked  as abandoned, 
and the author suggests using the [j0k3r/php-imgur-api-client](https://packagist.org/packages/j0k3r/php-imgur-api-client) package instead.