### PR TITLE
Update SessionStorage for Laravel 5.4.* Compatibility

### DIFF
--- a/src/TokenStorage/SessionStorage.php
+++ b/src/TokenStorage/SessionStorage.php
@@ -43,6 +43,6 @@ class SessionStorage implements Storage {
      */
     public function set($name, $value)
     {
-        $this->session->set($name, $value);
+        $this->session->put($name, $value);
     }
 }


### PR DESCRIPTION
Since Laravel 5.4.* Session "set" method was refactored to "put".